### PR TITLE
feat: Add support for watching node status

### DIFF
--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -470,22 +470,6 @@ spec:
         tier: control-plane
         k8s-app: kube-controller-manager
     spec:
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: tier
-                  operator: In
-                  values:
-                  - control-plane
-                - key: k8s-app
-                  operator: In
-                  values:
-                  - kube-controller-manager
-              topologyKey: kubernetes.io/hostname
       containers:
       - name: kube-controller-manager
         image: {{ .Images.Hyperkube }}
@@ -635,22 +619,6 @@ spec:
         tier: control-plane
         k8s-app: kube-scheduler
     spec:
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: tier
-                  operator: In
-                  values:
-                  - control-plane
-                - key: k8s-app
-                  operator: In
-                  values:
-                  - kube-scheduler
-              topologyKey: kubernetes.io/hostname
       containers:
       - name: kube-scheduler
         image: {{ .Images.Hyperkube }}

--- a/pkg/bootkube/status.go
+++ b/pkg/bootkube/status.go
@@ -37,10 +37,12 @@ func WaitUntilPodsRunning(c clientcmd.ClientConfig, pods []string, timeout time.
 }
 
 type statusController struct {
-	client        kubernetes.Interface
-	podStore      cache.Store
-	watchPods     []string
-	lastPodPhases map[string]corev1.PodPhase
+	client             kubernetes.Interface
+	podStore           cache.Store
+	nodeStore          cache.Store
+	watchPods          []string
+	lastPodPhases      map[string]corev1.PodPhase
+	lastNodeConditions map[string]corev1.NodeCondition
 }
 
 func NewStatusController(c clientcmd.ClientConfig, pods []string) (*statusController, error) {
@@ -56,6 +58,12 @@ func NewStatusController(c clientcmd.ClientConfig, pods []string) (*statusContro
 }
 
 func (s *statusController) Run() {
+	// TODO: launch a separate watcher for each component?
+	s.podWatcher()
+	s.nodeWatcher()
+}
+
+func (s *statusController) podWatcher() {
 	// TODO(yifan): Be more explicit about the labels so that we don't just
 	// reply on the prefix of the pod name when looking for the pods we are interested.
 	// E.g. For a scheduler pod, we will look for pods that has label `tier=control-plane`
@@ -74,15 +82,56 @@ func (s *statusController) Run() {
 		30*time.Minute,
 		cache.ResourceEventHandlerFuncs{},
 	)
+
 	s.podStore = podStore
+
 	go podController.Run(wait.NeverStop)
 }
 
+func (s *statusController) nodeWatcher() {
+	options := metav1.ListOptions{}
+
+	nodeStore, nodeController := cache.NewInformer(
+		&cache.ListWatch{
+			ListFunc: func(lo metav1.ListOptions) (runtime.Object, error) {
+				return s.client.CoreV1().Nodes().List(options)
+			},
+			WatchFunc: func(lo metav1.ListOptions) (watch.Interface, error) {
+				return s.client.CoreV1().Nodes().Watch(options)
+			},
+		},
+		&corev1.Node{},
+		30*time.Minute,
+		cache.ResourceEventHandlerFuncs{},
+	)
+
+	s.nodeStore = nodeStore
+
+	go nodeController.Run(wait.NeverStop)
+}
+
+// Why do we return bool error but never return error?
 func (s *statusController) AllRunning() (bool, error) {
+	var podsRunning, nodesReady, running bool
+
+	podsRunning = s.allPodsRunning()
+
+	if podsRunning {
+		nodesReady = s.allNodesReady()
+	}
+
+	if podsRunning && nodesReady {
+		running = true
+	}
+
+	return running, nil
+}
+
+func (s *statusController) allPodsRunning() bool {
 	ps, err := s.PodStatus()
 	if err != nil {
 		glog.Infof("Error retriving pod statuses: %v", err)
-		return false, nil
+		return false
 	}
 
 	if s.lastPodPhases == nil {
@@ -102,7 +151,36 @@ func (s *statusController) AllRunning() (bool, error) {
 			running = false
 		}
 	}
-	return running, nil
+
+	return running
+}
+
+func (s *statusController) allNodesReady() bool {
+	// Check node status to ensure all nodes are Ready
+	ns, err := s.NodeStatus()
+	if err != nil {
+		glog.Info("Error retrieving node conditions: %v", err)
+		return false
+	}
+
+	if s.lastNodeConditions == nil {
+		s.lastNodeConditions = ns
+	}
+
+	changed := !reflect.DeepEqual(ns, s.lastNodeConditions)
+	s.lastNodeConditions = ns
+
+	running := true
+	for node, condition := range ns {
+		if changed {
+			UserOutput("\tNode Conditions:%24s\t%s\n", node, condition)
+		}
+		if condition.Status != corev1.ConditionTrue {
+			running = false
+		}
+	}
+
+	return running
 }
 
 func (s *statusController) PodStatus() (map[string]corev1.PodPhase, error) {
@@ -129,5 +207,20 @@ func (s *statusController) PodStatus() (map[string]corev1.PodPhase, error) {
 			status[watchedPod] = p.Status.Phase
 		}
 	}
+	return status, nil
+}
+
+func (s *statusController) NodeStatus() (map[string]corev1.NodeCondition, error) {
+	status := make(map[string]corev1.NodeCondition)
+
+	for _, node := range s.nodeStore.List() {
+		for _, condition := range node.(*corev1.Node).Status.Conditions {
+			if condition.Type == corev1.NodeReady {
+				status[node.(*corev1.Node).Name] = condition
+				break
+			}
+		}
+	}
+
 	return status, nil
 }


### PR DESCRIPTION
This introduces support for waiting for all nodes to report back as Ready.
This fixes an edge case where self hosted pods come up on other control
plane nodes but not on the bootstrap node and all control plane nodes are
pointed to the bootstrap node.

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>