### PR TITLE
feat: add cluster name to configs and create context name

### DIFF
--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -110,6 +110,7 @@ var (
 // AssetConfig holds all configuration needed when generating
 // the default set of assets.
 type Config struct {
+	ClusterName            string
 	EtcdCACert             *x509.Certificate
 	EtcdClientCert         *x509.Certificate
 	EtcdClientKey          *rsa.PrivateKey

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -4,7 +4,7 @@ package internal
 var AdminKubeConfigTemplate = []byte(`apiVersion: v1
 kind: Config
 clusters:
-- name: local
+- name: {{ .Cluster }}
   cluster:
     server: {{ .Server }}
     certificate-authority-data: {{ .CACert }}
@@ -15,8 +15,10 @@ users:
     client-key-data: {{ .AdminKey }}
 contexts:
 - context:
-    cluster: local
+    cluster: {{ .Cluster }}
     user: admin
+  name: admin@{{ .Cluster }}
+current-context: admin@{{ .Cluster }}
 `)
 
 var KubeletKubeConfigTemplate = []byte(`apiVersion: v1

--- a/pkg/asset/k8s.go
+++ b/pkg/asset/k8s.go
@@ -161,6 +161,7 @@ func newKubeConfigAssets(assets Assets, conf Config) ([]Asset, error) {
 	}
 
 	cfg := struct {
+		Cluster              string
 		Server               string
 		CACert               string
 		AdminCert            string
@@ -168,6 +169,7 @@ func newKubeConfigAssets(assets Assets, conf Config) ([]Asset, error) {
 		BootstrapTokenID     string
 		BootstrapTokenSecret string
 	}{
+		Cluster:              conf.ClusterName,
 		Server:               conf.ControlPlaneEndpoint.String(),
 		CACert:               base64.StdEncoding.EncodeToString(caCert.Data),
 		AdminCert:            base64.StdEncoding.EncodeToString(adminCert.Data),


### PR DESCRIPTION
This PR adds a ClusterName value to the bootkube config struct, as well
as using that value to create a context name in the kubeconfig file.
This allows tools like kconf to merge various bootkube-created
kubeconfigs

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>