### PR TITLE
feat: support custom flags for controlplane

### DIFF
--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -110,28 +110,31 @@ var (
 // AssetConfig holds all configuration needed when generating
 // the default set of assets.
 type Config struct {
-	ClusterName            string
-	EtcdCACert             *x509.Certificate
-	EtcdClientCert         *x509.Certificate
-	EtcdClientKey          *rsa.PrivateKey
-	EtcdServers            []*url.URL
-	EtcdUseTLS             bool
-	ControlPlaneEndpoint   *url.URL
-	LocalAPIServerPort     int
-	CACert                 *x509.Certificate
-	CAPrivKey              *rsa.PrivateKey
-	AltNames               *tlsutil.AltNames
-	PodCIDR                *net.IPNet
-	ServiceCIDR            *net.IPNet
-	APIServiceIP           net.IP
-	DNSServiceIP           net.IP
-	CloudProvider          string
-	NetworkProvider        string
-	BootstrapSecretsSubdir string
-	Images                 ImageVersions
-	BootstrapTokenID       string
-	BootstrapTokenSecret   string
-	AESCBCEncryptionSecret string
+	ClusterName                string
+	APIServerExtraArgs         map[string]string
+	ControllerManagerExtraArgs map[string]string
+	SchedulerExtraArgs         map[string]string
+	EtcdCACert                 *x509.Certificate
+	EtcdClientCert             *x509.Certificate
+	EtcdClientKey              *rsa.PrivateKey
+	EtcdServers                []*url.URL
+	EtcdUseTLS                 bool
+	ControlPlaneEndpoint       *url.URL
+	LocalAPIServerPort         int
+	CACert                     *x509.Certificate
+	CAPrivKey                  *rsa.PrivateKey
+	AltNames                   *tlsutil.AltNames
+	PodCIDR                    *net.IPNet
+	ServiceCIDR                *net.IPNet
+	APIServiceIP               net.IP
+	DNSServiceIP               net.IP
+	CloudProvider              string
+	NetworkProvider            string
+	BootstrapSecretsSubdir     string
+	Images                     ImageVersions
+	BootstrapTokenID           string
+	BootstrapTokenSecret       string
+	AESCBCEncryptionSecret     string
 }
 
 // ImageVersions holds all the images (and their versions) that are rendered into the templates.

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -207,6 +207,9 @@ spec:
         - --tls-cert-file=/etc/kubernetes/secrets/apiserver.crt
         - --tls-private-key-file=/etc/kubernetes/secrets/apiserver.key
         - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
+        {{- range $k, $v := .APIServerExtraArgs }}
+        - --{{ $k }}="{{ $v }}"
+        {{- end }}
         env:
         - name: POD_IP
           valueFrom:
@@ -490,6 +493,9 @@ spec:
         - --root-ca-file=/etc/kubernetes/secrets/ca.crt
         - --service-account-private-key-file=/etc/kubernetes/secrets/service-account.key
         - --profiling=false
+        {{- range $k, $v := .ControllerManagerExtraArgs }}
+        - --{{ $k }}="{{ $v }}"
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -633,6 +639,9 @@ spec:
         - kube-scheduler
         - --leader-elect=true
         - --profiling=false
+        {{- range $k, $v := .SchedulerExtraArgs }}
+        - --{{ $k }}="{{ $v }}"
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/pkg/asset/k8s.go
+++ b/pkg/asset/k8s.go
@@ -37,7 +37,6 @@ type staticConfig struct {
 func newStaticAssets(imageVersions ImageVersions) Assets {
 	conf := staticConfig{Images: imageVersions}
 	assets := Assets{
-		MustCreateAssetFromTemplate(AssetPathScheduler, internal.SchedulerTemplate, conf),
 		MustCreateAssetFromTemplate(AssetPathSchedulerDisruption, internal.SchedulerDisruptionTemplate, conf),
 		MustCreateAssetFromTemplate(AssetPathControllerManagerDisruption, internal.ControllerManagerDisruptionTemplate, conf),
 		MustCreateAssetFromTemplate(AssetPathCoreDNSClusterRoleBinding, internal.CoreDNSClusterRoleBindingTemplate, conf),
@@ -60,6 +59,7 @@ func newStaticAssets(imageVersions ImageVersions) Assets {
 
 func newDynamicAssets(conf Config) Assets {
 	assets := Assets{
+		MustCreateAssetFromTemplate(AssetPathScheduler, internal.SchedulerTemplate, conf),
 		MustCreateAssetFromTemplate(AssetPathControllerManager, internal.ControllerManagerTemplate, conf),
 		MustCreateAssetFromTemplate(AssetPathControllerManagerSA, internal.ControllerManagerServiceAccount, conf),
 		MustCreateAssetFromTemplate(AssetPathControllerManagerRB, internal.ControllerManagerClusterRoleBinding, conf),


### PR DESCRIPTION
This PR adds in the ability to customize the controlplane components
that bootkube will create. Added a field in the config for each of the
components that accepts a map.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>