### PR TITLE
fix: add extraargs to bootstap components

### DIFF
--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -293,6 +293,9 @@ spec:
     - --audit-log-maxbackup=3
     - --audit-log-maxsize=50
     - --profiling=false
+    {{- range $k, $v := .APIServerExtraArgs }}
+    - --{{ $k }}={{ $v }}
+    {{- end }}
     env:
     - name: POD_IP
       valueFrom:
@@ -582,6 +585,9 @@ spec:
     - --root-ca-file=/etc/kubernetes/secrets/ca.crt
     - --service-account-private-key-file=/etc/kubernetes/secrets/service-account.key
     - --profiling=false
+    {{- range $k, $v := .ControllerManagerExtraArgs }}
+    - --{{ $k }}={{ $v }}
+    {{- end }}
     volumeMounts:
     - name: secrets
       mountPath: /etc/kubernetes/secrets
@@ -678,6 +684,9 @@ spec:
     - --kubeconfig=/etc/kubernetes/secrets/kubeconfig
     - --leader-elect=true
     - --profiling=false
+    {{- range $k, $v := .SchedulerExtraArgs }}
+    - --{{ $k }}={{ $v }}
+    {{- end }}
     volumeMounts:
     - name: secrets
       mountPath: /etc/kubernetes/secrets


### PR DESCRIPTION
This PR fixes a bug where the init node wasn't getting extra args
properly.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>