### PR TITLE
feat: add support for specifying cluster domain

### DIFF
--- a/cmd/bootkube/render.go
+++ b/cmd/bootkube/render.go
@@ -48,6 +48,7 @@ var (
 		serviceCIDR          string
 		cloudProvider        string
 		networkProvider      string
+		clusterDomain        string
 	}
 
 	imageVersions = asset.DefaultImages
@@ -68,6 +69,8 @@ func init() {
 	cmdRender.Flags().StringVar(&renderOpts.serviceCIDR, "service-cidr", "10.3.0.0/24", "The CIDR range of cluster services.")
 	cmdRender.Flags().StringVar(&renderOpts.cloudProvider, "cloud-provider", "", "The provider for cloud services.  Empty string for no provider")
 	cmdRender.Flags().StringVar(&renderOpts.networkProvider, "network-provider", "flannel", "CNI network provider (flannel, experimental-canal or experimental-calico).")
+	cmdRender.Flags().StringVar(&renderOpts.clusterDomain, "cluster-domain", "cluster.local", "The domain for a given cluster")
+
 }
 
 func runCmdRender(cmd *cobra.Command, args []string) error {
@@ -214,6 +217,7 @@ func flagsToAssetConfig() (c *asset.Config, err error) {
 		CloudProvider:        renderOpts.cloudProvider,
 		NetworkProvider:      renderOpts.networkProvider,
 		Images:               imageVersions,
+		ClusterDomain:        renderOpts.clusterDomain,
 	}, nil
 }
 

--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -124,6 +124,7 @@ type Config struct {
 	CACert                     *x509.Certificate
 	CAPrivKey                  *rsa.PrivateKey
 	AltNames                   *tlsutil.AltNames
+	ClusterDomain              string
 	PodCIDR                    *net.IPNet
 	ServiceCIDR                *net.IPNet
 	APIServiceIP               net.IP
@@ -161,6 +162,9 @@ func NewDefaultAssets(conf Config) (Assets, error) {
 
 	// Add kube-apiserver service IP
 	conf.AltNames.IPs = append(conf.AltNames.IPs, conf.APIServiceIP)
+
+	// Add kubernetes default svc with cluster domain to AltNames
+	conf.AltNames.DNSNames = append(conf.AltNames.DNSNames, "kubernetes.default.svc."+conf.ClusterDomain)
 
 	// Create a CA if none was provided.
 	if conf.CACert == nil {

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -891,7 +891,7 @@ data:
         log . {
             class error
         }
-        kubernetes cluster.local in-addr.arpa ip6.arpa {
+        kubernetes {{ .ClusterDomain }} in-addr.arpa ip6.arpa {
             pods insecure
             fallthrough in-addr.arpa ip6.arpa
         }

--- a/pkg/asset/tls.go
+++ b/pkg/asset/tls.go
@@ -130,7 +130,6 @@ func newAPIKeyAndCert(caCert *x509.Certificate, caPrivKey *rsa.PrivateKey, altNa
 		"kubernetes",
 		"kubernetes.default",
 		"kubernetes.default.svc",
-		"kubernetes.default.svc.cluster.local",
 	}...)
 
 	config := tlsutil.CertConfig{


### PR DESCRIPTION
This PR adds a cluster-domain flag to the render cli, as well as
supports all the options necessary for using something other than
`cluster.local` as the domain.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>