### PR TITLE
Add support for multiple Pod and Service subnets

### DIFF
--- a/cmd/bootkube/render.go
+++ b/cmd/bootkube/render.go
@@ -65,12 +65,11 @@ func init() {
 	cmdRender.Flags().StringVar(&renderOpts.etcdServers, "etcd-servers", defaultEtcdServers, "List of etcd servers URLs including host:port, comma separated")
 	cmdRender.Flags().StringVar(&renderOpts.controlPlaneEndpoint, "endpoint", "", "The control plane endpoint")
 	cmdRender.Flags().StringVar(&renderOpts.altNames, "api-server-alt-names", "", "List of SANs to use in api-server certificate. Example: 'IP=127.0.0.1,IP=127.0.0.2,DNS=localhost'. If empty, SANs will be extracted from the --api-servers flag.")
-	cmdRender.Flags().StringVar(&renderOpts.podCIDR, "pod-cidr", "10.2.0.0/16", "The CIDR range of cluster pods.")
-	cmdRender.Flags().StringVar(&renderOpts.serviceCIDR, "service-cidr", "10.3.0.0/24", "The CIDR range of cluster services.")
+	cmdRender.Flags().StringVar(&renderOpts.podCIDR, "pod-cidr", "10.2.0.0/16", "The CIDR range(s) of cluster pods.  If dual-stack, IPv4 must come first, separated by a comma.")
+	cmdRender.Flags().StringVar(&renderOpts.serviceCIDR, "service-cidr", "10.3.0.0/24", "The CIDR range(s) of cluster services.  If dual-stack, IPv4 must come first, seprated by a comma.")
 	cmdRender.Flags().StringVar(&renderOpts.cloudProvider, "cloud-provider", "", "The provider for cloud services.  Empty string for no provider")
 	cmdRender.Flags().StringVar(&renderOpts.networkProvider, "network-provider", "flannel", "CNI network provider (flannel, experimental-canal or experimental-calico).")
 	cmdRender.Flags().StringVar(&renderOpts.clusterDomain, "cluster-domain", "cluster.local", "The domain for a given cluster")
-
 }
 
 func runCmdRender(cmd *cobra.Command, args []string) error {
@@ -138,28 +137,57 @@ func flagsToAssetConfig() (c *asset.Config, err error) {
 		}
 	}
 
-	_, podNet, err := net.ParseCIDR(renderOpts.podCIDR)
-	if err != nil {
-		return nil, err
+	var podNets, serviceNets []*net.IPNet
+
+	for _, cidr := range strings.Split(renderOpts.podCIDR, ",") {
+		_, podNet, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return nil, err
+		}
+		podNets = append(podNets, podNet)
 	}
 
-	_, serviceNet, err := net.ParseCIDR(renderOpts.serviceCIDR)
-	if err != nil {
-		return nil, err
+	for _, cidr := range strings.Split(renderOpts.serviceCIDR, ",") {
+		_, serviceNet, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return nil, err
+		}
+		serviceNets = append(serviceNets, serviceNet)
 	}
 
-	if podNet.Contains(serviceNet.IP) || serviceNet.Contains(podNet.IP) {
-		return nil, fmt.Errorf("Pod CIDR %s and service CIDR %s must not overlap", podNet.String(), serviceNet.String())
+	if len(podNets) != len(serviceNets) {
+		return nil, fmt.Errorf("number of service CIDRs (%d) must match the number of pod CIDRs (%d)", len(serviceNets), len(podNets))
 	}
 
-	apiServiceIP, err := offsetServiceIP(serviceNet, apiOffset)
-	if err != nil {
-		return nil, err
+	if len(podNets) > 2 || len(podNets) < 1 {
+		return nil, errors.New("kubernetes requires exactly 1 or 2 pod networks, and they must be of different address families")
 	}
 
-	dnsServiceIP, err := offsetServiceIP(serviceNet, dnsOffset)
-	if err != nil {
-		return nil, err
+	if len(serviceNets) > 2 || len(serviceNets) < 1 {
+		return nil, errors.New("kubernetes requires exactly 1 or 2 service networks, and they must be of different address families")
+	}
+
+	for _, podNet := range podNets {
+		for _, svcNet := range serviceNets {
+			if podNet.Contains(svcNet.IP) || svcNet.Contains(podNet.IP) {
+				return nil, fmt.Errorf("Pod CIDR %s and service CIDR %s must not overlap", podNet.String(), svcNet.String())
+			}
+		}
+	}
+
+	var apiServiceIPs, dnsServiceIPs []net.IP
+	for _, serviceNet := range serviceNets {
+		apiServiceIP, err := offsetServiceIP(serviceNet, apiOffset)
+		if err != nil {
+			return nil, err
+		}
+		apiServiceIPs = append(apiServiceIPs, apiServiceIP)
+
+		dnsServiceIP, err := offsetServiceIP(serviceNet, dnsOffset)
+		if err != nil {
+			return nil, err
+		}
+		dnsServiceIPs = append(dnsServiceIPs, dnsServiceIP)
 	}
 
 	etcdServers, err := parseURLs(renderOpts.etcdServers)
@@ -191,8 +219,8 @@ func flagsToAssetConfig() (c *asset.Config, err error) {
 	}
 
 	// TODO: Find better option than asking users to make manual changes
-	if serviceNet.IP.String() != defaultServiceBaseIP {
-		fmt.Printf("You have selected a non-default service CIDR %s - be sure your kubelet service file uses --cluster-dns=%s\n", serviceNet.String(), dnsServiceIP.String())
+	if serviceNets[0].IP.String() != defaultServiceBaseIP {
+		fmt.Printf("You have selected a non-default service CIDR %s - be sure your kubelet service file uses --cluster-dns=%s\n", serviceNets[0].String(), dnsServiceIPs[0].String())
 	}
 
 	ep, err := url.Parse(endpoint)
@@ -210,14 +238,14 @@ func flagsToAssetConfig() (c *asset.Config, err error) {
 		CAPrivKey:            caPrivKey,
 		ControlPlaneEndpoint: ep,
 		AltNames:             altNames,
-		PodCIDR:              podNet,
-		ServiceCIDR:          serviceNet,
-		APIServiceIP:         apiServiceIP,
-		DNSServiceIP:         dnsServiceIP,
 		CloudProvider:        renderOpts.cloudProvider,
 		NetworkProvider:      renderOpts.networkProvider,
 		Images:               imageVersions,
 		ClusterDomain:        renderOpts.clusterDomain,
+		PodCIDRs:             podNets,
+		ServiceCIDRs:         serviceNets,
+		APIServiceIPs:        apiServiceIPs,
+		DNSServiceIPs:        dnsServiceIPs,
 	}, nil
 }
 

--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"reflect"
+	"strings"
 
 	"github.com/kubernetes-sigs/bootkube/pkg/tlsutil"
 )
@@ -103,9 +105,7 @@ const (
 	AssetPathBootstrapScheduler             = "bootstrap-manifests/bootstrap-scheduler.yaml"
 )
 
-var (
-	BootstrapSecretsDir = "/etc/kubernetes/bootstrap-secrets" // Overridden for testing.
-)
+var BootstrapSecretsDir = "/etc/kubernetes/bootstrap-secrets" // Overridden for testing.
 
 // AssetConfig holds all configuration needed when generating
 // the default set of assets.
@@ -125,10 +125,10 @@ type Config struct {
 	CAPrivKey                  *rsa.PrivateKey
 	AltNames                   *tlsutil.AltNames
 	ClusterDomain              string
-	PodCIDR                    *net.IPNet
-	ServiceCIDR                *net.IPNet
-	APIServiceIP               net.IP
-	DNSServiceIP               net.IP
+	PodCIDRs                   []*net.IPNet
+	ServiceCIDRs               []*net.IPNet
+	APIServiceIPs              []net.IP
+	DNSServiceIPs              []net.IP
 	CloudProvider              string
 	NetworkProvider            string
 	BootstrapSecretsSubdir     string
@@ -136,6 +136,115 @@ type Config struct {
 	BootstrapTokenID           string
 	BootstrapTokenSecret       string
 	AESCBCEncryptionSecret     string
+
+	// PodCIDR describes the networking subnet to be used for inter-pod networking.
+	//
+	// Deprecated: PodCIDR exists only for compatibility with older external
+	// systems.  Please use PodCIDRs instead, which allows for dual-stack
+	// configurations.
+	PodCIDR *net.IPNet
+
+	// ServiceCIDR describes the networking subnet to be used to expose services.
+	//
+	// Deprecated: ServiceCIDR exists only for compatibility with older external
+	// systems.  Please use ServiceCIDRs instead, which allows for dual-stack
+	// configurations.  If both are specified, only ServiceCIDRs will be used.
+	ServiceCIDR *net.IPNet
+
+	// APIServiceIP describes the in-cluster IP address by which the API Servers may be reached.
+	//
+	// Deprecated: APIServiceIP exists only for compatibility with older
+	// external systems.  Please use APIServiceIPs instead, which allows for
+	// dual-stack configurations.  If both are specified, only APIServiceIPs
+	// will be used.
+	APIServiceIP net.IP
+
+	// DNSServiceIP describes the in-cluster IP address by which the cluster DNS servers may be reached.
+	//
+	// Deprecated:  DNSServiceIP exists only for compatibility with older
+	// external systems.  Please use DNSServiceIPs instead, which allows for
+	// dual-stack configurations.  If both are specified, only DNSServiceIPs
+	// will be used.
+	DNSServiceIP net.IP
+}
+
+// BindAllAddress indicates the address to use when binding all IPs.  If this
+// is an IPv6 or dual-stack system, `::` will be returned.  Otherwise
+// `0.0.0.0`.
+func (c *Config) BindAllAddress() string {
+	if containsNonLocalIPv6(c.APIServiceIPs) {
+		return "::"
+	}
+	return "0.0.0.0"
+}
+
+// ServiceCIDRsString returns a "," concatenated string for the ServiceCIDRs
+func (c *Config) ServiceCIDRsString() string {
+	return joinStringsFromSliceOrSingle(stringerSlice(c.ServiceCIDRs), c.ServiceCIDR.String())
+}
+
+// PodCIDRsString returns a "," concatenated string for the PodCIDRs
+func (c *Config) PodCIDRsString() string {
+	return joinStringsFromSliceOrSingle(stringerSlice(c.PodCIDRs), c.PodCIDR.String())
+}
+
+// APIServiceIPsString returns a "," concatenated string for the APIServiceIPs
+func (c *Config) APIServiceIPsString() string {
+	return joinStringsFromSliceOrSingle(stringerSlice(c.APIServiceIPs), c.APIServiceIP.String())
+}
+
+// DNSServiceIPsString returns a "," concatenated string for the DNSServiceIPs
+func (c *Config) DNSServiceIPsString() string {
+	return joinStringsFromSliceOrSingle(stringerSlice(c.DNSServiceIPs), c.DNSServiceIP.String())
+}
+
+func stringerSlice(in interface{}) []string {
+	var ok bool
+
+	type Stringer interface {
+		String() string
+	}
+	var stringer Stringer
+
+	if in == nil {
+		return nil
+	}
+
+	r := reflect.ValueOf(in)
+	if r.Len() == 0 {
+		return nil
+	}
+
+	rval := make([]string, r.Len())
+	for i := 0; i < r.Len(); i++ {
+		stringer, ok = r.Index(i).Interface().(fmt.Stringer)
+		if !ok {
+			rval[i] = ""
+			continue
+		}
+		rval[i] = stringer.String()
+	}
+	return rval
+}
+
+func joinStringsFromSliceOrSingle(inSlice []string, inSingle string) string {
+	if len(inSlice) > 0 {
+		return strings.Join(inSlice, ",")
+	}
+	return inSingle
+}
+
+func containsNonLocalIPv6(in []net.IP) bool {
+	for _, ip := range in {
+		if ip == nil || ip.IsLoopback() || ip.IsUnspecified() {
+			continue
+		}
+
+		if ip.To4() == nil && ip.To16() != nil {
+			return true
+		}
+	}
+	return false
 }
 
 // ImageVersions holds all the images (and their versions) that are rendered into the templates.
@@ -161,7 +270,11 @@ func NewDefaultAssets(conf Config) (Assets, error) {
 	as = append(as, newDynamicAssets(conf)...)
 
 	// Add kube-apiserver service IP
-	conf.AltNames.IPs = append(conf.AltNames.IPs, conf.APIServiceIP)
+	if len(conf.APIServiceIPs) > 0 {
+		conf.AltNames.IPs = append(conf.AltNames.IPs, conf.APIServiceIPs...)
+	} else {
+		conf.AltNames.IPs = append(conf.AltNames.IPs, conf.APIServiceIP)
+	}
 
 	// Add kubernetes default svc with cluster domain to AltNames
 	conf.AltNames.DNSNames = append(conf.AltNames.DNSNames, "kubernetes.default.svc."+conf.ClusterDomain)

--- a/pkg/asset/asset_test.go
+++ b/pkg/asset/asset_test.go
@@ -1,0 +1,91 @@
+package asset
+
+import (
+	"net"
+	"strings"
+	"testing"
+)
+
+func TestJoinStringsFromSliceOrSingle(t *testing.T) {
+	var out string
+	testSingle := "hello"
+	testSlice := []string{"Hello", "World"}
+
+	if out = joinStringsFromSliceOrSingle(nil, testSingle); out != testSingle {
+		t.Errorf("single-only test failed: expected '%s', got '%s'", testSingle, out)
+	}
+
+	if out = joinStringsFromSliceOrSingle(testSlice, ""); out != strings.Join(testSlice, ",") {
+		t.Errorf("slice-only test failed: expected '%s', got '%s'", strings.Join(testSlice, ","), out)
+	}
+
+	if out = joinStringsFromSliceOrSingle(testSlice, testSingle); out != strings.Join(testSlice, ",") {
+		t.Errorf("single+slice test failed: expected '%s', got '%s'", strings.Join(testSlice, ","), out)
+	}
+
+	if out = joinStringsFromSliceOrSingle(nil, ""); out != "" {
+		t.Errorf("empty test failed: expected '%s', got '%s'", "", out)
+	}
+}
+
+func TestContainsNonLocalIPv6(t *testing.T) {
+	ipv4Loopback := net.ParseIP("127.0.0.1")
+	ipv4PublicUnicast := net.ParseIP("8.8.8.8")
+	ipv4PrivateUnicast := net.ParseIP("192.168.1.2")
+	ipv4Multicast := net.ParseIP("224.10.20.30")
+
+	ipv6Loopback := net.ParseIP("::1")
+	ipv6Unicast := net.ParseIP("2001:db8::1")
+	ipv6LinkLocal := net.ParseIP("fe80::db8:2")
+	ipv6Multicast := net.ParseIP("ff00::db8:3")
+
+	if containsNonLocalIPv6(nil) {
+		t.Errorf("empty set failed")
+	}
+	if containsNonLocalIPv6([]net.IP{ipv4Loopback, ipv4PublicUnicast, ipv4PrivateUnicast, ipv4Multicast, ipv6Loopback}) {
+		t.Errorf("all-false set check failed")
+	}
+	if !containsNonLocalIPv6([]net.IP{ipv6Unicast}) {
+		t.Errorf("single-true set failed")
+	}
+	if !containsNonLocalIPv6([]net.IP{ipv6LinkLocal, ipv4Loopback}) {
+		t.Errorf("true+v4Loop set failed")
+	}
+	if !containsNonLocalIPv6([]net.IP{ipv6Loopback, ipv6Multicast}) {
+		t.Errorf("true+v6Loop set failed")
+	}
+}
+
+func TestStringerSlice(t *testing.T) {
+	var out []string
+
+	if out = stringerSlice(nil); out != nil {
+		t.Errorf("nil input test did not have nil output: %v", out)
+	}
+
+	testNilSlice := []net.IP{}
+	out = stringerSlice(testNilSlice)
+	if len(out) != len(testNilSlice) {
+		t.Errorf("output mismatch (%d) for testNilSlice (%d)", len(out), len(testNilSlice))
+	}
+
+	testNonStringerSlice := []int{1, 2, 3, 4}
+	out = stringerSlice(testNonStringerSlice)
+	for i, s := range out {
+		if s != "" {
+			t.Errorf("nonStringerSlice[%d] produced non-nil output: %s", i, s)
+		}
+	}
+
+	testNormal1 := []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("0.0.0.0")}
+	out = stringerSlice(testNormal1)
+	if len(out) != len(testNormal1) {
+		t.Errorf("output mismatch (%d) for testNormal1 (%d)", len(out), len(testNormal1))
+	}
+	if out[0] != testNormal1[0].String() {
+		t.Errorf("output index 0 mismatch (%s) on testNormal (%s)", out[0], testNormal1[0].String())
+	}
+	if out[1] != testNormal1[1].String() {
+		t.Errorf("output index 1 mismatch (%s) on testNormal (%s)", out[1], testNormal1[1].String())
+	}
+}

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -173,7 +173,7 @@ spec:
         - --allow-privileged=true
         - --anonymous-auth=false
         - --authorization-mode=Node,RBAC
-        - --bind-address=0.0.0.0
+        - --bind-address={{ .BindAllAddress }}
         - --client-ca-file=/etc/kubernetes/secrets/ca.crt
         - --requestheader-client-ca-file=/etc/kubernetes/secrets/front-proxy-ca.crt
         - --requestheader-allowed-names=front-proxy-client
@@ -203,7 +203,7 @@ spec:
         - --kubelet-client-key=/etc/kubernetes/secrets/apiserver-kubelet-client.key
         - --secure-port={{ .LocalAPIServerPort }}
         - --service-account-key-file=/etc/kubernetes/secrets/service-account.pub
-        - --service-cluster-ip-range={{ .ServiceCIDR }}
+        - --service-cluster-ip-range={{ .ServiceCIDRsString }}
         - --tls-cert-file=/etc/kubernetes/secrets/apiserver.crt
         - --tls-private-key-file=/etc/kubernetes/secrets/apiserver.key
         - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
@@ -260,7 +260,7 @@ spec:
     - --advertise-address=$(POD_IP)
     - --allow-privileged=true
     - --authorization-mode=Node,RBAC
-    - --bind-address=0.0.0.0
+    - --bind-address={{ .BindAllAddress }}
     - --client-ca-file=/etc/kubernetes/secrets/ca.crt
     - --requestheader-client-ca-file=/etc/kubernetes/secrets/front-proxy-ca.crt
     - --requestheader-allowed-names=front-proxy-client
@@ -281,7 +281,7 @@ spec:
     - --kubelet-client-key=/etc/kubernetes/secrets/apiserver-kubelet-client.key
     - --secure-port={{ .LocalAPIServerPort }}
     - --service-account-key-file=/etc/kubernetes/secrets/service-account.pub
-    - --service-cluster-ip-range={{ .ServiceCIDR }}
+    - --service-cluster-ip-range={{ .ServiceCIDRsString }}
     - --cloud-provider={{ .CloudProvider }}
     - --tls-cert-file=/etc/kubernetes/secrets/apiserver.crt
     - --tls-private-key-file=/etc/kubernetes/secrets/apiserver.key
@@ -487,8 +487,8 @@ spec:
         - --use-service-account-credentials
         - --allocate-node-cidrs=true
         - --cloud-provider={{ .CloudProvider }}
-        - --cluster-cidr={{ .PodCIDR }}
-        - --service-cluster-ip-range={{ .ServiceCIDR }}
+        - --cluster-cidr={{ .PodCIDRsString }}
+        - --service-cluster-ip-range={{ .ServiceCIDRsString }}
         - --cluster-signing-cert-file=/etc/kubernetes/secrets/ca.crt
         - --cluster-signing-key-file=/etc/kubernetes/secrets/ca.key
         - --configure-cloud-routes=false
@@ -574,8 +574,8 @@ spec:
     - ./hyperkube
     - kube-controller-manager
     - --allocate-node-cidrs=true
-    - --cluster-cidr={{ .PodCIDR }}
-    - --service-cluster-ip-range={{ .ServiceCIDR }}
+    - --cluster-cidr={{ .PodCIDRsString }}
+    - --service-cluster-ip-range={{ .ServiceCIDRsString }}
     - --cloud-provider={{ .CloudProvider }}
     - --cluster-signing-cert-file=/etc/kubernetes/secrets/ca.crt
     - --cluster-signing-key-file=/etc/kubernetes/secrets/ca.key
@@ -736,7 +736,7 @@ spec:
         command:
         - ./hyperkube
         - kube-proxy
-        - --cluster-cidr={{ .PodCIDR }}
+        - --cluster-cidr={{ .PodCIDRsString }}
         - --hostname-override=$(NODE_NAME)
         - --kubeconfig=/etc/kubernetes/kubeconfig
         - --proxy-mode=iptables
@@ -1024,7 +1024,7 @@ metadata:
 spec:
   selector:
     k8s-app: kube-dns
-  clusterIP: {{ .DNSServiceIP }}
+  clusterIP: {{ index .DNSServiceIPsString 0 }}
   ports:
     - name: dns
       port: 53


### PR DESCRIPTION
Adds dual stack (IPv4 + IPv6) support for:
  - Service subnets
  - Pod subnets
  - API service
  - DNS service

Ref issue #1079

Signed-off-by: Seán C McCord <ulexus@gmail.com>
(cherry picked from commit bec40d58d01bda70e6a9417f4003c75fbd5ded66)